### PR TITLE
fix the logic to init the SpacyParser

### DIFF
--- a/sng_parser/backends/spacy_parser.py
+++ b/sng_parser/backends/spacy_parser.py
@@ -43,11 +43,11 @@ class SpacyParser(ParserBackend):
             default_model = 'en_core_web_sm'
 
         self.model = model
-        if self.model is not None:
+        if self.model is None:
             self.model = default_model
 
         try:
-            self.nlp = spacy.load(model)
+            self.nlp = spacy.load(self.model)
         except OSError as e:
             raise ImportError('Unable to load the English model. Run `python -m spacy download en` first.') from e
 


### PR DESCRIPTION
The logic how the SpacyParser is loaded has been fixed. If no model is given, initialize to the default for Spacy Model  in English. 