### PR TITLE
Support passing a `doc` directly to `parse` with the spaCy backend

### DIFF
--- a/sng_parser/backends/spacy_parser.py
+++ b/sng_parser/backends/spacy_parser.py
@@ -52,7 +52,7 @@ class SpacyParser(ParserBackend):
         except OSError as e:
             raise ImportError('Unable to load the English model. Run `python -m spacy download en` first.') from e
 
-    def parse(self, sentence, return_doc=False):
+    def parse(self, sentence, doc=None, return_doc=False):
         """
         The spaCy-based parser parse the sentence into scene graphs based on the dependency parsing
         of the sentence by spaCy.
@@ -67,7 +67,7 @@ class SpacyParser(ParserBackend):
             in the code for better explanation.
             3. determine all the relations among entities.
         """
-        doc = self.nlp(sentence)
+        doc = doc or self.nlp(sentence)
 
         # Step 1: determine the entities.
         entities = list()


### PR DESCRIPTION
This change allows passing a spaCy doc directly to `parse` in the spaCy backend. I know it breaks the abstraction, but it allows us to reuse an existing doc and thus avoids the extra processing of re-computing it, because, AFAIK, spaCy doesn't cache the result.