### PR TITLE
Fix that the symbol `SpacyParser` is `None`

### DIFF
--- a/sng_parser/parser.py
+++ b/sng_parser/parser.py
@@ -96,6 +96,7 @@ class Parser(object):
             cls._backend_registry[backend.__identifier__] = backend
         except Exception as e:
             raise ImportError('Unable to register backend: {}.'.format(backend.__name__)) from e
+        return cls
 
 
 _default_parser = None

--- a/sng_parser/parser.py
+++ b/sng_parser/parser.py
@@ -96,7 +96,7 @@ class Parser(object):
             cls._backend_registry[backend.__identifier__] = backend
         except Exception as e:
             raise ImportError('Unable to register backend: {}.'.format(backend.__name__)) from e
-        return cls
+        return backend
 
 
 _default_parser = None


### PR DESCRIPTION
If you do:

```python
from sng_parser.backend import SpacyParser
```

then, you're gonna find that `SpacyParser` is `None`. This is because its decorator doesn't return anything, which is the same as returning `None`. The class takes this output as its representation. This change fixes this.