### PR TITLE
fix the pronoun filter error; fix relation with "is" as AUX; make __flatten_conjunction recursive

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -37,6 +37,11 @@ def main():
     demo('The woman is a pianist.')
     demo('A giraffe grazing a tree in the wildness with other wildlife.')
     demo('Cow standing on sidewalk in city area near shops.')
+    demo('She is playing the piano.')  # wrong, contain "she"
+    demo('A woman is next to a piano.')  # wrong
+    demo('A woman is in front of a piano.')  # wrong
+    demo('A woman is standing next to a piano.')  # correct 
+    demo('A bowl of rice, noodle and grains.')  # wrong
 
     print('Input your own sentence. Type q to quit.')
     while True:

--- a/sng_parser/backends/spacy_parser.py
+++ b/sng_parser/backends/spacy_parser.py
@@ -203,7 +203,7 @@ class SpacyParser(ParserBackend):
                         'lemma_relation': entity.root.head.head.lemma_ + ' ' + entity.root.head.lemma_
                     }
                 # E.g., A [piano] is next to a [woman].
-                elif entity.root.head.head.dep_ == 'acomp' and entity.root.head.head.head.pos_ == 'AUX':
+                elif entity.root.head.head.dep_ in ('amod', 'advmod', 'acomp') and entity.root.head.head.head.pos_ == 'AUX':
                     relation = {
                         'subject': relation_subj[entity.root.head.head.head.i],
                         'object': entity.root.i,


### PR DESCRIPTION
1. The pronoun filter "entity.root.lemma_ == '-PRON-'" is out of date. Fixed it.
2. Deal with error cases: "A woman is in front of a piano." and "A woman is next to a piano."
3. __flatten_conjunction should be recursive to get all conjunctions. Fixed it with example "A bowl of rice, noodle and grains."